### PR TITLE
Touch up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var defaultCacheControl = 'public, max-age=31536000'; // ~1 year
 var cacheMap = {
   'index.html': 'private, no-cache, no-store, must-revalidate' // no caching
 };
-var perFileCallback function (localFile, stat, s3ParamsCallback) {
+var perFileCallback = function (localFile, stat, s3ParamsCallback) {
   var key = localFile.replace(directory + '/', '');
   var s3Params = {
     ContentEncoding: 'gzip',

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ uploadDirToS3(directory, bucket, keyPrefix, defaultS3Params)
 ... see Simple example ...
 var defaultCacheControl = 'public, max-age=31536000'; // ~1 year
 var cacheMap = {
-	'index.html': 'private, no-cache, no-store, must-revalidate' // no caching
+  'index.html': 'private, no-cache, no-store, must-revalidate' // no caching
 };
 var perFileCallback function (localFile, stat, s3ParamsCallback) {
-	var key = localFile.replace(directory + '/', '');
-	var s3Params = {
-		ContentEncoding: 'gzip',
-		CacheControl: cacheMap[key] || defaultCacheControl
-	};
-	s3ParamsCallback(null, s3Params);
+  var key = localFile.replace(directory + '/', '');
+  var s3Params = {
+    ContentEncoding: 'gzip',
+    CacheControl: cacheMap[key] || defaultCacheControl
+  };
+  s3ParamsCallback(null, s3Params);
 });
 
 uploadDirToS3(directory, bucket, keyPrefix, perFileCallback)


### PR DESCRIPTION
- fixed a typo in the `README.md` code sample
- converted tabs to spaces in `README.md` - done for consistency since some of the indentation was previously done using two spaces and some using tab characters
